### PR TITLE
Feature/dispose wrappers

### DIFF
--- a/src/Contiva.SAP.NWRfc.Abstractions/Contiva.SAP.NWRfc.Abstractions.csproj
+++ b/src/Contiva.SAP.NWRfc.Abstractions/Contiva.SAP.NWRfc.Abstractions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Contiva.Functional" Version="1.0.0" />
+    <PackageReference Include="Contiva.Functional" Version="1.1.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Contiva.SAP.NWRfc.Abstractions/IDataContainer.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/IDataContainer.cs
@@ -3,7 +3,7 @@ using LanguageExt;
 
 namespace Contiva.SAP.NWRfc
 {
-    public interface IDataContainer
+    public interface IDataContainer : IDisposable
     {
         Either<RfcErrorInfo, Unit> SetField<T>(string name, T value);
         Either<RfcErrorInfo, T> GetField<T>(string name);

--- a/src/Contiva.SAP.NWRfc.Abstractions/IDataContainerHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/IDataContainerHandle.cs
@@ -1,6 +1,8 @@
-﻿namespace Contiva.SAP.NWRfc
+﻿using System;
+
+namespace Contiva.SAP.NWRfc
 {
-    public interface IDataContainerHandle
+    public interface IDataContainerHandle: IDisposable
     {
     }
 }

--- a/src/Contiva.SAP.NWRfc.Abstractions/IFunctionDescriptionHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/IFunctionDescriptionHandle.cs
@@ -1,6 +1,8 @@
-﻿namespace Contiva.SAP.NWRfc
+﻿using System;
+
+namespace Contiva.SAP.NWRfc
 {
-    public interface IFunctionDescriptionHandle
+    public interface IFunctionDescriptionHandle: IDisposable
     {
 
     }

--- a/src/Contiva.SAP.NWRfc.Abstractions/IFunctionHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/IFunctionHandle.cs
@@ -2,7 +2,7 @@
 
 namespace Contiva.SAP.NWRfc
 {
-    public interface IFunctionHandle : IDataContainerHandle, IDisposable
+    public interface IFunctionHandle : IDataContainerHandle
     {
 
     }

--- a/src/Contiva.SAP.NWRfc.Abstractions/ITableHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/ITableHandle.cs
@@ -2,7 +2,7 @@
 
 namespace Contiva.SAP.NWRfc
 {
-    public interface ITableHandle: IDataContainerHandle, IDisposable
+    public interface ITableHandle: IDataContainerHandle
     {
 
     }

--- a/src/Contiva.SAP.NWRfc.Abstractions/ITypeDescriptionHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Abstractions/ITypeDescriptionHandle.cs
@@ -1,6 +1,8 @@
-﻿namespace Contiva.SAP.NWRfc
+﻿using System;
+
+namespace Contiva.SAP.NWRfc
 {
-    public interface ITypeDescriptionHandle
+    public interface ITypeDescriptionHandle : IDisposable
     {
 
     }

--- a/src/Contiva.SAP.NWRfc.Core/Connection.cs
+++ b/src/Contiva.SAP.NWRfc.Core/Connection.cs
@@ -32,10 +32,8 @@ namespace Contiva.SAP.NWRfc
                         {
                             case CreateFunctionMessage createFunctionMessage:
                             {
-                                var result =
-                                    from desc in rfcRuntime.GetFunctionDescription(handle,createFunctionMessage.FunctionName)
-                                    from func in rfcRuntime.CreateFunction(desc)
-                                    select new Function(func, rfcRuntime) as object;
+                                var result = rfcRuntime.GetFunctionDescription(handle, createFunctionMessage.FunctionName).Use(
+                                    used => used.Bind(rfcRuntime.CreateFunction)).Map(f => (object) new Function(f,rfcRuntime));
 
                                 return (handle, result);
 

--- a/src/Contiva.SAP.NWRfc.Core/Contiva.SAP.NWRfc.Core.csproj
+++ b/src/Contiva.SAP.NWRfc.Core/Contiva.SAP.NWRfc.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Contiva.Functional" Version="1.0.0" />
+    <PackageReference Include="Contiva.Functional" Version="1.1.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Contiva.SAP.NWRfc.Core/DataContainer.cs
+++ b/src/Contiva.SAP.NWRfc.Core/DataContainer.cs
@@ -186,7 +186,19 @@ namespace Contiva.SAP.NWRfc
         }
 
 
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _handle?.Dispose();
+            }
+        }
 
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 
 }

--- a/src/Contiva.SAP.NWRfc.Core/Function.cs
+++ b/src/Contiva.SAP.NWRfc.Core/Function.cs
@@ -16,8 +16,8 @@ namespace Contiva.SAP.NWRfc
 
         protected override Either<RfcErrorInfo, RfcFieldInfo> GetFieldInfo(string name)
         {
-            return _rfcRuntime.GetFunctionDescription(Handle)
-                .Bind(handle => _rfcRuntime.GetFunctionParameterDescription(handle, name)).Map(r => (RfcFieldInfo) r);
+            return _rfcRuntime.GetFunctionDescription(Handle).Use(used => used
+                .Bind(handle => _rfcRuntime.GetFunctionParameterDescription(handle, name)).Map(r => (RfcFieldInfo) r));
 
         }
     }

--- a/src/Contiva.SAP.NWRfc.Core/Function.cs
+++ b/src/Contiva.SAP.NWRfc.Core/Function.cs
@@ -14,12 +14,6 @@ namespace Contiva.SAP.NWRfc
             _rfcRuntime = rfcRuntime;
         }
 
-        public void Dispose()
-        {
-            Handle?.Dispose();
-            Handle = null;
-        }
-
         protected override Either<RfcErrorInfo, RfcFieldInfo> GetFieldInfo(string name)
         {
             return _rfcRuntime.GetFunctionDescription(Handle)

--- a/src/Contiva.SAP.NWRfc.Core/FunctionalDataContainerExtensions.cs
+++ b/src/Contiva.SAP.NWRfc.Core/FunctionalDataContainerExtensions.cs
@@ -23,7 +23,7 @@ namespace Contiva.SAP.NWRfc
         public static Task<Either<RfcErrorInfo, TDataContainer>> SetStructure<TDataContainer>(this Task<Either<RfcErrorInfo, TDataContainer>> self, string structureName, Func<Either<RfcErrorInfo, IStructure>, Either<RfcErrorInfo, IStructure>> map)
             where TDataContainer : IDataContainer
         {
-            return self.BindAsync(dc => dc.GetStructure(structureName).Apply(map).Map(u => dc));
+            return self.BindAsync(dc => dc.GetStructure(structureName).Use(used => used.Apply(map).Map(u => dc)));
         }
 
         public static Task<Either<RfcErrorInfo, TDataContainer>> SetTable<TDataContainer, TInput>(
@@ -36,11 +36,11 @@ namespace Contiva.SAP.NWRfc
         public static Task<Either<RfcErrorInfo, TDataContainer>> SetTable<TDataContainer, TInput>(this Task<Either<RfcErrorInfo, TDataContainer>> self, string tableName, Func<IEnumerable<TInput>> inputListFunc, Func<Either<RfcErrorInfo, IStructure>, TInput, Either<RfcErrorInfo, IStructure>> map)
             where TDataContainer : IDataContainer
         {
-            return self.BindAsync(dc => dc.GetTable(tableName).Map(table => (dc, table, inputListFunc))
+            return self.BindAsync(dc => dc.GetTable(tableName).Use(used=> used.Map(table => (dc, table, inputListFunc))
 
                     .Bind(t => t.inputListFunc().Map(
                         input => t.table.AppendRow().Apply(row=>map(row,input))
-                    ).Traverse(l => l).Map(_ => dc)));
+                    ).Traverse(l => l).Map(_ => dc))));
 
         }
     }

--- a/src/Contiva.SAP.NWRfc.Core/TypeDescriptionDataContainer.cs
+++ b/src/Contiva.SAP.NWRfc.Core/TypeDescriptionDataContainer.cs
@@ -15,8 +15,8 @@ namespace Contiva.SAP.NWRfc
 
         protected override Either<RfcErrorInfo, RfcFieldInfo> GetFieldInfo(string name)
         {
-            return _rfcRuntime.GetTypeDescription(_handle)
-                .Bind(handle => _rfcRuntime.GetTypeFieldDescription(handle, name));
+            return _rfcRuntime.GetTypeDescription(_handle).Use(used => used
+                .Bind(handle => _rfcRuntime.GetTypeFieldDescription(handle, name)));
 
         }
     }

--- a/src/Contiva.SAP.NWRfc.Native.clr/HandleWrappers.cpp
+++ b/src/Contiva.SAP.NWRfc.Native.clr/HandleWrappers.cpp
@@ -16,28 +16,28 @@ namespace Contiva {
 
 				void FunctionDescriptionHandle::DestroyHandle(RFC_FUNCTION_DESC_HANDLE handle)
 				{
-					RfcDestroyFunctionDesc(handle, NULL);
+					RFC_RC rc = RfcDestroyFunctionDesc(handle, NULL);
 				}
 
 				void TypeDescriptionHandle::DestroyHandle(RFC_TYPE_DESC_HANDLE handle)
 				{
-					RfcDestroyTypeDesc(handle, NULL);
+					RFC_RC rc = RfcDestroyTypeDesc(handle, NULL);
 				}
 
 				void FunctionHandle::DestroyHandle(RFC_FUNCTION_HANDLE handle)
 				{
-					RfcDestroyFunction(handle, NULL);
+					RFC_RC rc = RfcDestroyFunction(handle, NULL);
 				}
 
 				void StructureHandle::DestroyHandle(RFC_STRUCTURE_HANDLE handle)
 				{
-					RfcDestroyStructure(handle, NULL);
+					RFC_RC rc = RfcDestroyStructure(handle, NULL);
 				}
 
 				void TableHandle::DestroyHandle(RFC_TABLE_HANDLE handle)
 				{
 
-					RfcDestroyTable(handle, NULL);
+					RFC_RC rc = RfcDestroyTable(handle, NULL);
 				}
 			}
 		}

--- a/src/Contiva.SAP.NWRfc.Native/FunctionDescriptionHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Native/FunctionDescriptionHandle.cs
@@ -2,6 +2,9 @@
 {
     public class FunctionDescriptionHandle : IFunctionDescriptionHandle
     {
-
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/Contiva.SAP.NWRfc.Native/StructureHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Native/StructureHandle.cs
@@ -2,6 +2,9 @@
 {
     public class StructureHandle : IStructureHandle
     {
-
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/Contiva.SAP.NWRfc.Native/TypeDescriptionHandle.cs
+++ b/src/Contiva.SAP.NWRfc.Native/TypeDescriptionHandle.cs
@@ -2,6 +2,9 @@
 {
     public class TypeDescriptionHandle : ITypeDescriptionHandle
     {
-
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/test/SAPSystemTests/SAPSystemTests.csproj
+++ b/test/SAPSystemTests/SAPSystemTests.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net471</TargetFramework>
     <UserSecretsId>D662BD92-26B8-421C-9C14-33E009457A3B</UserSecretsId>
     <LangVersion>latest</LangVersion>
-
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
In c# Code handles are not disposed in all cases. This change adds IDisposeable to all handles. 

However this will currently not affect the actual destroy of handles, because except function handles all handles are currently cached and will not be destroyed by RFC SDK.